### PR TITLE
fix bug groupped columns width without columns flexGrow

### DIFF
--- a/src/selectors/columnWidths.js
+++ b/src/selectors/columnWidths.js
@@ -78,19 +78,14 @@ function columnWidths(columnGroupProps, columnProps, scrollEnabledY, width) {
  */
 function flexWidths(columnGroupProps, columnProps, viewportWidth) {
   let remainingFlexGrow = getTotalFlexGrow(columnProps);
-  if (remainingFlexGrow === 0) {
-    return {
-      newColumnGroupProps: columnGroupProps,
-      newColumnProps: columnProps,
-    };
-  }
 
   const columnsWidth = getTotalWidth(columnProps);
   let remainingFlexWidth = Math.max(viewportWidth - columnsWidth, 0);
 
   const newColumnProps = map(columnProps, column => {
     const { flexGrow } = column;
-    if (!flexGrow) {
+
+    if (!flexGrow || remainingFlexGrow === 0) {
       return column;
     }
 


### PR DESCRIPTION
Fixed bug for grouped columns that have no flexGrow parameter

## Description
If all columns of the table do not have the flex Grow parameter specified, the result is that the column grouping header row may not display correctly.

## Motivation and Context
If you are open example
https://schrodinger.github.io/fixed-data-table-2/example-column-groups.html
and remove all flexGrow parameters, then columGroup row isEmpty. Width is set to NaN, and css style is broken.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
